### PR TITLE
Fix issue with querying customers by domain

### DIFF
--- a/src/linear/customers/get-customer-by-name-or-domains.ts
+++ b/src/linear/customers/get-customer-by-name-or-domains.ts
@@ -5,8 +5,9 @@ const queryByNameOrDomains = `query CustomerByNameOrDomains($name: String!, $dom
   customers(
     filter: {
       or: [
-        { name: { eqIgnoreCase: $name } }
+        # Due to a bug on Linear's side, these clauses need to be in this order:
         { domains: { some: { in: $domains } } }
+        { name: { eqIgnoreCase: $name } }
       ]
     }
     first: 1


### PR DESCRIPTION
The "where: clauses in this "or" need to be in the opposite order due to a quirk of the API.